### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Add the following to your .pre-commit-config.yaml file:
       - --managedir=myproj
       - --requirements=proj/requirements.txt
       language_version: python3
+      pass_filenames: false
 ```
 
 The three arguments are required and allude to:


### PR DESCRIPTION
When `pre-commit run --all-files` is run, the hook will run multiple times due to being passed all filenames. However, we really just want this hook to run once for the whole project. Therefore I propose changing the README to have `pass_filenames: false` as a default suggested option for the hook.

Reference: https://github.com/pre-commit/pre-commit/issues/836